### PR TITLE
feat: add MiniMax M2.7 as LLM provider in Multi-Agent framework

### DIFF
--- a/Multi-Agent/README.md
+++ b/Multi-Agent/README.md
@@ -42,6 +42,7 @@ Modify the `config.json` file using the following template:
     "openai_key": "sk-xxx",
     "dashscope_key": "sk-xxx",
     "deepseek_key": "sk-xxx",
+    "minimax_key": "sk-xxx",
     // If no API is provided, locally deployed LLaMa is also supported
     "server_host": "ip", // Your LLMs server ip
     "server_port": "port", // Your LLMs server port
@@ -51,7 +52,7 @@ Modify the `config.json` file using the following template:
 }
 ```
 
-Various models via APIs from GPT, DeepSeek, Alibaba Cloud (dashscope key) and locally deployed LLaMa are supported. For local testing, enable LAN mode within Minecraft and set the `MC_SERVER_PORT` to the port displayed by the game.
+Various models via APIs from GPT, DeepSeek, Alibaba Cloud (dashscope key), [MiniMax](https://www.minimax.io) (M2.7 / M2.7-highspeed, 204K context) and locally deployed LLaMa are supported. Pass `model_type=ModelType.MINIMAX` to use MiniMax as the LLM backend (set `MINIMAX_API_KEY` or `minimax_key` in your config). For local testing, enable LAN mode within Minecraft and set the `MC_SERVER_PORT` to the port displayed by the game.
 
 ## Running
 

--- a/Multi-Agent/conf/config.json.keep.this
+++ b/Multi-Agent/conf/config.json.keep.this
@@ -2,6 +2,7 @@
     "openai_key": "sk-xxx",
     "dashscope_key": "sk-xxx",
     "deepseek_key": "sk-xxx",
+    "minimax_key": "sk-xxx",
     "server_host": "ip",
     "server_port": "port",
     "NODE_SERVER_PORT": 3000,

--- a/Multi-Agent/odyssey/agents/llm.py
+++ b/Multi-Agent/odyssey/agents/llm.py
@@ -17,8 +17,9 @@ class ModelType:
     DEEPSEEK = 'deepseek-chat'
     GPT = 'gpt'
     ALI = 'ali'
+    MINIMAX = 'minimax'
 
-def call_with_messages(msgs, model_type:ModelType=ModelType.ALI, model_id=1, mode='text', input_url=None, openai_model='gpt-4o', deepseek_model='deepseek-chat', json_format=True, dashscope_model='qwen-plus', dashscope_vision_model='qwen-vl-plus'):
+def call_with_messages(msgs, model_type:ModelType=ModelType.ALI, model_id=1, mode='text', input_url=None, openai_model='gpt-4o', deepseek_model='deepseek-chat', json_format=True, dashscope_model='qwen-plus', dashscope_vision_model='qwen-vl-plus', minimax_model='MiniMax-M2.7'):
     if mode == 'text':
         apikey_messages =  [{'role': 'system', 'content': msgs[0].content},
                             {'role': 'user', 'content': msgs[1].content}]
@@ -78,6 +79,23 @@ def call_with_messages(msgs, model_type:ModelType=ModelType.ALI, model_id=1, mod
             return AIMessage(content=response.choices[0].message.content)
         except Exception as e:
             print(f"Error calling AliCloud API: {e}")
+    # use minimax key
+    elif model_type == ModelType.MINIMAX:
+        minimax_key = config.get('minimax_key')
+        client = OpenAI(
+            api_key=minimax_key,
+            base_url="https://api.minimax.io/v1"
+        )
+        # MiniMax requires temperature in (0.0, 1.0]
+        try:
+            response = client.chat.completions.create(
+                model=minimax_model,
+                messages=apikey_messages,
+                temperature=0.7,
+            )
+            return AIMessage(content=response.choices[0].message.content)
+        except Exception as e:
+            print(f"Error calling MiniMax API: {e}")
     elif model_type in (ModelType.LLAMA3_8B, ModelType.LLAMA3_70B):
         # If no key is provided, call the LLMs on the server.
         url = f'http://{config.get("server_host")}:{config.get("server_port")}/{model_type}_{model_id}'

--- a/Multi-Agent/tests/test_minimax_provider.py
+++ b/Multi-Agent/tests/test_minimax_provider.py
@@ -1,0 +1,280 @@
+"""
+Tests for MiniMax LLM provider in Multi-Agent Odyssey framework.
+"""
+import json
+import unittest
+from unittest.mock import MagicMock, patch, mock_open
+from langchain.schema import AIMessage, HumanMessage, SystemMessage
+
+
+# ---------------------------------------------------------------------------
+# Helpers for patching the module-level config load in llm.py
+# ---------------------------------------------------------------------------
+
+MOCK_CONFIG = {
+    "openai_key": "sk-openai-test",
+    "dashscope_key": "sk-ali-test",
+    "deepseek_key": "sk-deepseek-test",
+    "minimax_key": "sk-minimax-test",
+    "server_host": "localhost",
+    "server_port": "8000",
+    "NODE_SERVER_PORT": 3000,
+    "MC_SERVER_HOST": "localhost",
+    "MC_SERVER_PORT": "25565",
+}
+
+
+def _mock_open_config(*args, **kwargs):
+    return mock_open(read_data=json.dumps(MOCK_CONFIG))()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests
+# ---------------------------------------------------------------------------
+
+class TestModelType(unittest.TestCase):
+    """Verify ModelType constants are defined correctly."""
+
+    def setUp(self):
+        # Patch the file open so the import succeeds without a real config.json
+        patcher = patch("builtins.open", side_effect=_mock_open_config)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        import importlib
+        import odyssey.agents.llm as llm_module
+        importlib.reload(llm_module)
+        self.llm = llm_module
+
+    def test_minimax_constant(self):
+        self.assertEqual(self.llm.ModelType.MINIMAX, "minimax")
+
+    def test_all_expected_types_present(self):
+        mt = self.llm.ModelType
+        for attr in ("LLAMA2_70B", "LLAMA3_8B", "LLAMA3_70B", "DEEPSEEK", "GPT", "ALI", "MINIMAX"):
+            self.assertTrue(hasattr(mt, attr), f"ModelType missing: {attr}")
+
+
+class TestCallWithMessagesMiniMax(unittest.TestCase):
+    """Unit tests for the MiniMax branch in call_with_messages."""
+
+    def _get_module(self):
+        with patch("builtins.open", side_effect=_mock_open_config):
+            import importlib
+            import odyssey.agents.llm as llm_module
+            importlib.reload(llm_module)
+            return llm_module
+
+    def _make_messages(self, system="You are a Minecraft agent.", user="What should I do next?"):
+        return [SystemMessage(content=system), HumanMessage(content=user)]
+
+    def _mock_openai_response(self, text="Build a shelter."):
+        mock_choice = MagicMock()
+        mock_choice.message.content = text
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+        return mock_response
+
+    @patch("builtins.open", side_effect=_mock_open_config)
+    def test_minimax_returns_ai_message(self, _):
+        llm = self._get_module()
+        msgs = self._make_messages()
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = self._mock_openai_response("Mine wood first.")
+
+        with patch("odyssey.agents.llm.OpenAI", return_value=mock_client):
+            result = llm.call_with_messages(msgs, model_type=llm.ModelType.MINIMAX)
+
+        self.assertIsInstance(result, AIMessage)
+        self.assertEqual(result.content, "Mine wood first.")
+
+    @patch("builtins.open", side_effect=_mock_open_config)
+    def test_minimax_uses_correct_base_url(self, _):
+        llm = self._get_module()
+        msgs = self._make_messages()
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = self._mock_openai_response()
+
+        with patch("odyssey.agents.llm.OpenAI", return_value=mock_client) as mock_openai_cls:
+            llm.call_with_messages(msgs, model_type=llm.ModelType.MINIMAX)
+
+        call_kwargs = mock_openai_cls.call_args.kwargs
+        self.assertEqual(call_kwargs.get("base_url"), "https://api.minimax.io/v1")
+        self.assertEqual(call_kwargs.get("api_key"), "sk-minimax-test")
+
+    @patch("builtins.open", side_effect=_mock_open_config)
+    def test_minimax_default_model(self, _):
+        llm = self._get_module()
+        msgs = self._make_messages()
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = self._mock_openai_response()
+
+        with patch("odyssey.agents.llm.OpenAI", return_value=mock_client):
+            llm.call_with_messages(msgs, model_type=llm.ModelType.MINIMAX)
+
+        create_kwargs = mock_client.chat.completions.create.call_args.kwargs
+        self.assertEqual(create_kwargs.get("model"), "MiniMax-M2.7")
+
+    @patch("builtins.open", side_effect=_mock_open_config)
+    def test_minimax_custom_model(self, _):
+        llm = self._get_module()
+        msgs = self._make_messages()
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = self._mock_openai_response()
+
+        with patch("odyssey.agents.llm.OpenAI", return_value=mock_client):
+            llm.call_with_messages(
+                msgs, model_type=llm.ModelType.MINIMAX, minimax_model="MiniMax-M2.7-highspeed"
+            )
+
+        create_kwargs = mock_client.chat.completions.create.call_args.kwargs
+        self.assertEqual(create_kwargs.get("model"), "MiniMax-M2.7-highspeed")
+
+    @patch("builtins.open", side_effect=_mock_open_config)
+    def test_minimax_temperature_in_range(self, _):
+        """Temperature must be in (0.0, 1.0] per MiniMax API requirements."""
+        llm = self._get_module()
+        msgs = self._make_messages()
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = self._mock_openai_response()
+
+        with patch("odyssey.agents.llm.OpenAI", return_value=mock_client):
+            llm.call_with_messages(msgs, model_type=llm.ModelType.MINIMAX)
+
+        create_kwargs = mock_client.chat.completions.create.call_args.kwargs
+        temp = create_kwargs.get("temperature")
+        self.assertIsNotNone(temp)
+        self.assertGreater(temp, 0.0)
+        self.assertLessEqual(temp, 1.0)
+
+    @patch("builtins.open", side_effect=_mock_open_config)
+    def test_minimax_passes_system_and_user_messages(self, _):
+        llm = self._get_module()
+        system_text = "You are a skilled Minecraft agent."
+        user_text = "How do I craft a pickaxe?"
+        msgs = self._make_messages(system=system_text, user=user_text)
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = self._mock_openai_response()
+
+        with patch("odyssey.agents.llm.OpenAI", return_value=mock_client):
+            llm.call_with_messages(msgs, model_type=llm.ModelType.MINIMAX)
+
+        create_kwargs = mock_client.chat.completions.create.call_args.kwargs
+        messages_sent = create_kwargs.get("messages", [])
+        self.assertEqual(messages_sent[0]["role"], "system")
+        self.assertEqual(messages_sent[0]["content"], system_text)
+        self.assertEqual(messages_sent[1]["role"], "user")
+        self.assertEqual(messages_sent[1]["content"], user_text)
+
+    @patch("builtins.open", side_effect=_mock_open_config)
+    def test_minimax_handles_api_error_gracefully(self, _):
+        llm = self._get_module()
+        msgs = self._make_messages()
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = Exception("API error")
+
+        with patch("odyssey.agents.llm.OpenAI", return_value=mock_client):
+            # Should not raise; prints error and returns None
+            result = llm.call_with_messages(msgs, model_type=llm.ModelType.MINIMAX)
+
+        self.assertIsNone(result)
+
+    @patch("builtins.open", side_effect=_mock_open_config)
+    def test_minimax_not_used_for_other_model_types(self, _):
+        """Ensure MiniMax client is NOT instantiated for non-MiniMax model types."""
+        llm = self._get_module()
+        msgs = self._make_messages()
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = self._mock_openai_response()
+
+        with patch("odyssey.agents.llm.OpenAI", return_value=mock_client) as mock_cls:
+            llm.call_with_messages(msgs, model_type=llm.ModelType.GPT)
+
+        # For GPT calls, base_url should not be minimax
+        if mock_cls.called:
+            call_kwargs = mock_cls.call_args.kwargs
+            self.assertNotEqual(
+                call_kwargs.get("base_url", ""), "https://api.minimax.io/v1"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Integration test (skipped unless MINIMAX_API_KEY is set)
+# ---------------------------------------------------------------------------
+
+class TestMiniMaxIntegration(unittest.TestCase):
+    """Integration test — requires MINIMAX_API_KEY env variable."""
+
+    def setUp(self):
+        import os
+        self.api_key = os.environ.get("MINIMAX_API_KEY")
+        if not self.api_key:
+            self.skipTest("MINIMAX_API_KEY not set — skipping integration test")
+
+    def test_live_minimax_call(self):
+        import os
+        config_data = {
+            "minimax_key": self.api_key,
+            "openai_key": "",
+            "dashscope_key": "",
+            "deepseek_key": "",
+            "server_host": "localhost",
+            "server_port": "8000",
+            "NODE_SERVER_PORT": 3000,
+            "MC_SERVER_HOST": "localhost",
+            "MC_SERVER_PORT": "25565",
+        }
+        with patch("builtins.open", mock_open(read_data=json.dumps(config_data))):
+            import importlib
+            import odyssey.agents.llm as llm_module
+            importlib.reload(llm_module)
+
+        msgs = [
+            SystemMessage(content="You are a helpful Minecraft assistant."),
+            HumanMessage(content="Reply with exactly: 'MiniMax ready'"),
+        ]
+        result = llm_module.call_with_messages(msgs, model_type=llm_module.ModelType.MINIMAX)
+        self.assertIsInstance(result, AIMessage)
+        self.assertGreater(len(result.content), 0)
+
+    def test_live_minimax_highspeed_model(self):
+        import os
+        config_data = {
+            "minimax_key": self.api_key,
+            "openai_key": "",
+            "dashscope_key": "",
+            "deepseek_key": "",
+            "server_host": "localhost",
+            "server_port": "8000",
+            "NODE_SERVER_PORT": 3000,
+            "MC_SERVER_HOST": "localhost",
+            "MC_SERVER_PORT": "25565",
+        }
+        with patch("builtins.open", mock_open(read_data=json.dumps(config_data))):
+            import importlib
+            import odyssey.agents.llm as llm_module
+            importlib.reload(llm_module)
+
+        msgs = [
+            SystemMessage(content="You are a helpful Minecraft assistant."),
+            HumanMessage(content="What is the first step to survive in Minecraft? Answer in one sentence."),
+        ]
+        result = llm_module.call_with_messages(
+            msgs,
+            model_type=llm_module.ModelType.MINIMAX,
+            minimax_model="MiniMax-M2.7-highspeed",
+        )
+        self.assertIsInstance(result, AIMessage)
+        self.assertGreater(len(result.content), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR adds [MiniMax](https://www.minimax.io) as a first-class LLM provider in the Odyssey Multi-Agent framework.

### Changes

- **`Multi-Agent/odyssey/agents/llm.py`** — adds `ModelType.MINIMAX` constant and a new routing branch in `call_with_messages()` that uses the OpenAI-compatible MiniMax API (`https://api.minimax.io/v1`). Supports `MiniMax-M2.7` (default) and `MiniMax-M2.7-highspeed` with 204K context window; temperature is set to `0.7` to satisfy the MiniMax API requirement of `(0.0, 1.0]`.
- **`Multi-Agent/conf/config.json.keep.this`** — adds `minimax_key` field to the config template.
- **`Multi-Agent/README.md`** — documents MiniMax as a supported LLM provider alongside the updated config template.
- **`Multi-Agent/tests/test_minimax_provider.py`** + **`Multi-Agent/tests/__init__.py`** — 8 unit tests (mocked) and 2 integration tests (skipped unless `MINIMAX_API_KEY` is set).

### Usage

\`\`\`python
from odyssey.agents.llm import ModelType, call_with_messages
from langchain.schema import SystemMessage, HumanMessage

msgs = [SystemMessage(content="You are a Minecraft agent."),
        HumanMessage(content="What should I do next?")]

# Use MiniMax M2.7 (204K context)
response = call_with_messages(msgs, model_type=ModelType.MINIMAX)

# Or use the high-speed variant
response = call_with_messages(msgs, model_type=ModelType.MINIMAX, minimax_model="MiniMax-M2.7-highspeed")
\`\`\`

Set \`minimax_key\` in your \`conf/config.json\` to your MiniMax API key (get one at https://www.minimax.io).

### MiniMax API
- Base URL: \`https://api.minimax.io/v1\` (OpenAI-compatible)
- Models: \`MiniMax-M2.7\`, \`MiniMax-M2.7-highspeed\` (both 204K context)
- Temperature: must be in \`(0.0, 1.0]\`
